### PR TITLE
YH-1904: Fixed: Incorrect font size and spacing between blocks in the…

### DIFF
--- a/src/shared/ui/AccordionMentor/AccordionMentor.module.css
+++ b/src/shared/ui/AccordionMentor/AccordionMentor.module.css
@@ -119,7 +119,7 @@
 }
 
 .move-title.accordion[open] .title {
-	opacity: 0;
+	display: none;
 	pointer-events: none;
 }
 
@@ -133,6 +133,7 @@
 @media (width < 768px) {
 	.accordion {
 		padding: 10px;
+		
 	}
 
 	.media {

--- a/src/widgets/Mentor/EducationSection/ui/EducationSteps/EducationSteps.tsx
+++ b/src/widgets/Mentor/EducationSection/ui/EducationSteps/EducationSteps.tsx
@@ -17,7 +17,7 @@ export const EducationSteps = () => {
 			<Text className={styles.title} variant="head2">
 				{t(Mentor.EDUCATION_SUBTITLE)}
 			</Text>
-			<Flex direction="column" gap="20">
+			<Flex direction="column" gap="10">
 				{EDUCATION_STEPS.map((step) => (
 					<EducationStep
 						key={step.id}


### PR DESCRIPTION
… “Mentoring - Education” section

- Исправлен размер заголовков в нумерованных блоках секции "Образование" на мобильной ширине.
- Исправлен отступ между нумерованными блоками.
- Скрытый заголовок аккордеона больше не занимает место в потоке.