### PR TITLE
YH-1934: adjust mentor banner title styles

### DIFF
--- a/src/widgets/Mentor/BannerSection/ui/BannerTitle/BannerTitle.module.css
+++ b/src/widgets/Mentor/BannerSection/ui/BannerTitle/BannerTitle.module.css
@@ -1,22 +1,25 @@
 .title {
 	margin-top: 20px;
-  max-width: 785px;
-  text-align: center;
-  text-transform: uppercase;
-  white-space: pre-wrap;
+	max-width: 785px;
+	text-align: center;
+	text-transform: uppercase;
+	white-space: pre-wrap;
+}
+
+.title.title-text {
 	font-size: 50px;
 }
 
 @media screen and (width < 1280px) {
-	.title {
+	.title.title-text {
 		line-height: 115%;
 		font-size: 40px;
 	}
 }
 
 @media screen and (width < 768px) {
-  .title {
+	.title.title-text {
 		line-height: 120%;
-    font-size: 24px;
-  }
+		font-size: 24px;
+	}
 }

--- a/src/widgets/Mentor/BannerSection/ui/BannerTitle/BannerTitle.tsx
+++ b/src/widgets/Mentor/BannerSection/ui/BannerTitle/BannerTitle.tsx
@@ -9,7 +9,7 @@ export const BannerTitle = () => {
 	const t = useTranslations(i18Namespace.mentor);
 
 	return (
-		<Text variant="head1" className={styles.title}>
+		<Text variant="head1" className={`${styles.title} ${styles['title-text']}`}>
 			{t(Mentor.BANNER_TITLE)}
 		</Text>
 	);


### PR DESCRIPTION

Проблема была в том, что нужные стили могли переопределяться из-за порядка подключения CSS-файлов. Исправил это, повысив специфичность селектора через дополнительный класс. Локально на ширине 360px отображение соответствует макету.
