### PR TITLE
YH-1899: fix community card link styles

### DIFF
--- a/src/shared/ui/Card/Card.tsx
+++ b/src/shared/ui/Card/Card.tsx
@@ -16,6 +16,7 @@ export interface CardProps {
 	children?: ReactNode;
 	className?: string;
 	contentClassName?: string;
+	linkClassName?: string;
 	title?: string;
 	actionRoute?: string;
 	actionTitle?: string;
@@ -46,6 +47,7 @@ export const Card = ({
 	children,
 	className = '',
 	contentClassName = '',
+	linkClassName = '',
 	withShadow = false,
 	withOutsideShadow = false,
 	withBorder = false,
@@ -85,7 +87,7 @@ export const Card = ({
 						<Link
 							href={actionRoute}
 							{...actionOptions}
-							className={classNames(styles.link, styles[`link-${actionPositionX}`], {
+							className={classNames(styles.link, styles[`link-${actionPositionX}`], linkClassName, {
 								[styles['link-bottom']]: isActionPositionBottom,
 								[styles['link-disabled']]: actionDisabled,
 							})}

--- a/src/widgets/Mentor/CommunitySection/ui/CommunityCard/CommunityCard.module.css
+++ b/src/widgets/Mentor/CommunitySection/ui/CommunityCard/CommunityCard.module.css
@@ -1,37 +1,47 @@
 .card {
-	gap: 0;
-	padding: 20px;
-	height: 361px;
+  gap: 0;
+  padding: 20px;
+  height: 361px;
 }
 
 .card-content {
-	height: 100%;
+  height: 100%;
 }
 
 .icon-wrapper {
-	flex-shrink: 0;
-	width: 29px;
-	height: 29px;
+  flex-shrink: 0;
+  width: 29px;
+  height: 29px;
 }
 
 .title {
-	margin-top: auto;
-	margin-bottom: 8px;
+  margin-top: auto;
+  margin-bottom: 8px;
 }
 
 @media (width < 1280px) {
-	.card {
-		height: 278px;
-	}
-	
-	h3.title {
-		font-size: var(--font-size-h-xs);
-	}
+  .card {
+    height: 278px;
+  }
+
+  h3.title {
+    font-size: var(--font-size-h-xs);
+  }
 }
 
 @media (width < 768px) {
-	.card {
-		padding: 10px;
-		height: 257px;
-	}
+  .card {
+    padding: 10px;
+    height: 257px;
+  }
+}
+
+@media (width <= 368px) {
+  .link {
+    left: 10px;
+  }
+
+  .link > p {
+    font-weight: 500;
+  }
 }

--- a/src/widgets/Mentor/CommunitySection/ui/CommunityCard/CommunityCard.tsx
+++ b/src/widgets/Mentor/CommunitySection/ui/CommunityCard/CommunityCard.tsx
@@ -16,6 +16,7 @@ export const CommunityCard = ({ title, description, linkText, linkUrl }: Communi
 		<Card
 			className={styles.card}
 			contentClassName={styles['card-content']}
+			linkClassName={styles['link']}
 			actionTitle={linkText}
 			actionRoute={linkUrl}
 			actionPositionX="start"


### PR DESCRIPTION
- в компоненте Card.tsx , добавлен селектор для гиперссылки, приходит через props
- исправлены стили для гиперссылки, отступ слева и font-weight

Задача: https://tracker.yandex.ru/YH-1899