### PR TITLE
YH-1889: fixed paddings in FAQ at 1440px

### DIFF
--- a/src/shared/ui/AccordionMentor/AccordionMentor.module.css
+++ b/src/shared/ui/AccordionMentor/AccordionMentor.module.css
@@ -92,7 +92,7 @@
 }
 
 .content {
-	padding: 17px 0 0;
+	padding: 10px 0 0;
 	color: var(--text-color-light);
 }
 
@@ -149,11 +149,11 @@
 	.with-media .content p:last-child {
 		max-width: 100%;
 	}
-	
+
 	.heading {
 		flex-wrap: wrap;
 	}
-	
+
 	h3.title {
 		order: 3;
 		margin-top: 10px;

--- a/src/widgets/Mentor/FaqSection/ui/FaqList/FaqList.tsx
+++ b/src/widgets/Mentor/FaqSection/ui/FaqList/FaqList.tsx
@@ -64,7 +64,7 @@ export const FaqList = () => {
 	];
 
 	return (
-		<Flex direction="column" gap="20" className={styles.wrapper}>
+		<Flex direction="column" className={styles.wrapper}>
 			<Flex direction="column" gap="20" className={styles.content}>
 				{steps.map(({ id, title, description }) => (
 					<AccordionMentor key={id} number={id} title={t(title)} defaultOpen={false}>

--- a/src/widgets/Mentor/SectionHeader/ui/SectionHeader/SectionHeader.module.css
+++ b/src/widgets/Mentor/SectionHeader/ui/SectionHeader/SectionHeader.module.css
@@ -6,7 +6,6 @@
 	margin-bottom: 30px;
 }
 
-
 .description {
 	max-width: 493px;
 }


### PR DESCRIPTION
Исправлены отступы в компонентах FaqList.tsx и AccordionMentor.tsx. Исправления сделаны в файлах:
src/widgets/Mentor/FaqSection/ui/FaqList/FaqList.tsx
и
src/shared/ui/AccordionMentor/AccordionMentor.module.css

Ожидаемый результат:

1 Блоки с вопросами не сдвинуты вправо (выполнено)
2 Расстояние между вопросом и ответом равно 10px (выполнено)
3 Ширина блока фиксирована на 443px, текст переносится на новые строки по этой ширине
4 И номер, и кнопка расположены на первой "строчке" текста вопроса

Пункты 3 и 4 отображаются корректно на разрешении 1440px. Предлагаю закрыть как не баг, скриншот прилагаю

<img width="1440" height="900" alt="Снимок экрана 2026-05-19 в 13 02 56" src="https://github.com/user-attachments/assets/3e72cc38-2b49-4f64-ae29-40bfbacbf6f2" />


Задача: https://tracker.yandex.ru/YH-1889