### PR TITLE
YH-2122: added flex-wrap to Flex component

### DIFF
--- a/src/entities/tasks/ui/TaskCard/TaskCard.tsx
+++ b/src/entities/tasks/ui/TaskCard/TaskCard.tsx
@@ -49,7 +49,7 @@ export const TaskCard = ({
 				) : (
 					<Skeleton variant="blur" text={<Text variant="body4">{t(Tasks.TITLE_HIDE)}</Text>} />
 				)}
-				<Flex direction="row" gap="10" align="center">
+				<Flex direction="row" gap="10" align="center" wrap="wrap">
 					<TaskDifficultyChip key={id} difficulty={difficulty} />
 					{languagesSlot}
 					<StatusChip


### PR DESCRIPTION
Исправлено отображение дочерних элементов компонента Flex в TaskCard

Ранее дочерние элементы сжимались из-за выключенного переноса - flex-wrap. Передал компоненту Flex соответствующий проп (wrap="wrap") для включения переноса. Результат:

<img width="1070" height="969" alt="image" src="https://github.com/user-attachments/assets/4633c3d7-7a2b-4579-a75a-7f6636906f09" />

Задача: https://tracker.yandex.ru/YH-2122