### PR TITLE
YH-2293: code update for problem YH-1923

### DIFF
--- a/src/_pages/MentorPage/ui/PricingSection/PricingSection/PricingSection.module.css
+++ b/src/_pages/MentorPage/ui/PricingSection/PricingSection/PricingSection.module.css
@@ -14,3 +14,9 @@
 		gap: 10px;
 	}
 }
+
+@media screen and (width < 368px) {
+	.content {
+		gap: 10px;
+	}
+}

--- a/src/_pages/MentorPage/ui/PricingSection/TariffCard/TariffCard.module.css
+++ b/src/_pages/MentorPage/ui/PricingSection/TariffCard/TariffCard.module.css
@@ -49,3 +49,18 @@
 		min-height: unset;
 	}
 }
+
+@media screen and (width < 368px) {
+	.card {
+		padding: 10px;
+	}
+
+	.title {
+		margin-top: 32px;
+    letter-spacing: -0.05rem;
+	}
+
+	.button {
+    padding: 0 30px;
+	}
+}

--- a/src/_pages/MentorPage/ui/PricingSection/TariffCardAdvantages/TariffCardAdvantages.module.css
+++ b/src/_pages/MentorPage/ui/PricingSection/TariffCardAdvantages/TariffCardAdvantages.module.css
@@ -19,3 +19,8 @@
 	}
 }
 
+@media screen and (width < 368px) {
+	.list-item > p {
+		letter-spacing: -0.07rem;
+	}
+}

--- a/src/_pages/MentorPage/ui/PricingSection/TariffCardAdvantages/TariffCardAdvantages.tsx
+++ b/src/_pages/MentorPage/ui/PricingSection/TariffCardAdvantages/TariffCardAdvantages.tsx
@@ -22,7 +22,7 @@ export const TariffCardAdvantages = ({ advantages, isInverted }: TariffCardAdvan
 				{advantages.map((advantage) => (
 					<Flex
 						componentType="li"
-						gap="10"
+						gap="16"
 						align="center"
 						key={advantage}
 						className={styles['list-item']}

--- a/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.module.css
+++ b/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.module.css
@@ -173,6 +173,14 @@
 }
 
 @media screen and (width < 368px) {
+	.card {
+		min-height: auto;
+	}
+
+	.experienced-content {
+		position: relative;
+	}
+
 	.wrapper {
 		gap: 12px;
 	}
@@ -183,5 +191,18 @@
 
 	.description-experienced {
 		line-height: 1.3;
+	}
+
+  .title-consultation {
+    margin-top: 104px;
+  }
+
+	.title-experienced {
+		margin-top: 36px;
+	}
+
+	.badges {
+		top: 9px;
+		right: 20px;
 	}
 }

--- a/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.module.css
+++ b/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.module.css
@@ -30,8 +30,7 @@
 
 .background {
 	background:
-		linear-gradient(101.11deg, rgb(246 246 246 / 0%) 73.72%, rgb(142 120 255 / 67%) 95.19%),
-		#fff;
+		linear-gradient(101.11deg, rgb(246 246 246 / 0%) 73.72%, rgb(142 120 255 / 67%) 95.19%), #fff;
 }
 
 .badges {
@@ -64,9 +63,9 @@
 	width: 150%;
 	height: 2px;
 	border-radius: 21px;
-	background: #E84B4B;
+	background: #e84b4b;
 	transform: translate(-50%, -50%) rotate(45deg);
-	content: "";
+	content: '';
 }
 
 .badge-red::after {
@@ -76,9 +75,9 @@
 	width: 150%;
 	height: 2px;
 	border-radius: 21px;
-	background: #E84B4B;
+	background: #e84b4b;
 	transform: translate(-50%, -50%) rotate(-45deg);
-	content: "";
+	content: '';
 }
 
 .badge-outline {
@@ -121,14 +120,14 @@
 	.wrapper {
 		grid-template-columns: 1fr 1fr;
 	}
-	
+
 	.badges {
 		position: absolute;
 		right: 20px;
 		z-index: -1;
 		gap: 16px;
 	}
-	
+
 	.badge-red {
 		margin-top: 8px;
 		width: 64px;
@@ -166,9 +165,23 @@
 	p.title {
 		font-size: var(--font-size-h-xs);
 	}
-	
+
 	.card {
 		padding: 10px;
 		min-height: 337px;
+	}
+}
+
+@media screen and (width < 368px) {
+	.wrapper {
+		gap: 12px;
+	}
+
+	.button {
+		padding: 0 30px;
+	}
+
+	.description-experienced {
+		line-height: 1.3;
 	}
 }

--- a/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.module.css
+++ b/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.module.css
@@ -150,9 +150,9 @@
 		line-height: 1.3;
 	}
 
-  .title-consultation {
-    margin-top: 104px;
-  }
+  	.title-consultation {
+    	margin-top: 104px;
+  	}	
 
 	.title-experienced {
 		margin-top: 36px;

--- a/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.module.css
+++ b/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.module.css
@@ -80,41 +80,6 @@
 	content: '';
 }
 
-.badge-outline {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
-	align-items: center;
-	margin-top: 85px;
-	width: 150px;
-	height: 150px;
-	box-shadow:
-		0 12px 30px 0 #6a0bff0d,
-		0 -4px 15px 0 #d8bfff33 inset,
-		0 2px 6px 0 #6a0bff12;
-	border-radius: 10px;
-	background: #fff;
-}
-
-.badge-outline::before {
-	position: absolute;
-	inset: 0;
-	padding: 1px;
-	border-radius: 10px;
-	background: linear-gradient(138.11deg, #6a0bff -27.99%, rgb(255 255 255 / 0%) 58.22%);
-	content: '';
-	mask:
-		linear-gradient(#fff 0 0) content-box,
-		linear-gradient(#fff 0 0);
-	mask-composite: xor;
-	mask-composite: exclude;
-	pointer-events: none;
-}
-
-.badge-outline-text {
-	font-weight: 700;
-}
 
 @media (width < 1280px) {
 	.wrapper {
@@ -134,27 +99,19 @@
 		height: 64px;
 	}
 
-	.badge-outline {
-		margin-top: 8px;
-		width: 80px;
-		height: 80px;
-	}
-	
+
+
 	h2.badge-red-text {
 		font-size: var(--font-size-h-xs);
 	}
 
-	h2.badge-outline-text {
-		font-size: var(--font-size-h-xs);
-	}
+	
 
 	p.badge-red-subtext {
 		font-size: var(--font-size-p-xss);
 	}
 
-	p.badge-outline-subtext {
-		font-size: var(--font-size-p-xss);
-	}
+
 }
 
 @media (width < 768px) {

--- a/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.tsx
+++ b/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.tsx
@@ -53,7 +53,10 @@ export const InfoBlock = () => {
 						<Text variant="body6" className={styles.title}>
 							{t(Mentor.PRICING_INFO_EXPERIENCED_TITLE)}
 						</Text>
-						<Text variant="body3-accent" className={styles.description}>
+						<Text
+							variant="body3-accent"
+							className={classNames(styles.description, styles['description-experienced'])}
+						>
 							{t(Mentor.PRICING_INFO_EXPERIENCED_DESCRIPTION)}
 						</Text>
 						<Button

--- a/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.tsx
+++ b/src/_pages/MentorPage/ui/PricingSection/infoBlock/InfoBlock.tsx
@@ -25,7 +25,7 @@ export const InfoBlock = () => {
 					size="large"
 					status={{ text: t(Mentor.PRICING_INFO_BADGE_INSTEAD), variant: 'green' }}
 				/>
-				<Text variant="body6" className={styles.title}>
+				<Text variant="body6" className={classNames(styles.title, styles['title-consultation'])}>
 					{t(Mentor.PRICING_INFO_POSTPAY_TITLE)}
 				</Text>
 				<Text variant="body3-accent" className={styles.description}>
@@ -47,10 +47,10 @@ export const InfoBlock = () => {
 				className={classNames(styles.card, styles.background)}
 				contentClassName={styles['wrapper-content']}
 			>
-				<Flex maxHeight gap="32">
+				<Flex maxHeight gap="32" className={styles['experienced-content']}>
 					<Flex direction="column" maxHeight flex={1}>
 						<Badge icon="lightning" wrapperClassName={styles['icon-wrapper']} />
-						<Text variant="body6" className={styles.title}>
+						<Text variant="body6" className={classNames(styles.title, styles['title-experienced'])}>
 							{t(Mentor.PRICING_INFO_EXPERIENCED_TITLE)}
 						</Text>
 						<Text
@@ -77,14 +77,6 @@ export const InfoBlock = () => {
 							</Text>
 							<Text variant="body3" color="white-900" className={styles['badge-red-subtext']}>
 								{t(Mentor.PRICING_INFO_BADGE_OFFER)}
-							</Text>
-						</div>
-						<div className={styles['badge-outline']}>
-							<Text variant="head2" color="purple-900" className={styles['badge-outline-text']}>
-								100%
-							</Text>
-							<Text variant="body3" color="black-700" className={styles['badge-outline-subtext']}>
-								{t(Mentor.PRICING_INFO_BADGE_POSTPAY)}
 							</Text>
 						</div>
 					</Flex>

--- a/src/_pages/MentorPage/ui/SectionHeader/SectionHeader/SectionHeader.module.css
+++ b/src/_pages/MentorPage/ui/SectionHeader/SectionHeader/SectionHeader.module.css
@@ -22,3 +22,13 @@
 		font-size: 24px;
 	}
 }
+
+@media screen and (width < 368px) {
+	.wrapper {
+		margin-bottom: 19px;
+	}
+
+	.description {
+		letter-spacing: 0.02rem;
+	}
+}


### PR DESCRIPTION
Supersedes #104

Задача - https://tracker.yandex.ru/YH-2293

Перенос исправлений вёрстки вёрстки PricingSection/InfoBlock под 360px на актуальный develop после рефакторинга структуры (widgets → _pages).

1. Перенесены 2 коммита с правками вёрстки из PR #104 - tarifflist + infoblock layout

2. Убран неиспользуемый CSS (.badge-outline и производные), оставшийся 
  от удалённого элемента
  
3. Вёрстка сверена с Figma-макетом на разрешении 360px — соответствует


4. Конфликтов с develop нет