### PR TITLE
YH-2294: update YH-1904 mobile accordion fixes

### DIFF
--- a/src/_pages/MentorPage/ui/EducationSection/EducationSteps/EducationSteps.tsx
+++ b/src/_pages/MentorPage/ui/EducationSection/EducationSteps/EducationSteps.tsx
@@ -17,7 +17,7 @@ export const EducationSteps = () => {
 			<Text className={styles.title} variant="head2">
 				{t(Mentor.EDUCATION_SUBTITLE)}
 			</Text>
-			<Flex direction="column" gap="20">
+			<Flex direction="column" gap="10">
 				{EDUCATION_STEPS.map((step) => (
 					<EducationStep
 						key={step.id}

--- a/src/shared/ui/AccordionMentor/AccordionMentor.module.css
+++ b/src/shared/ui/AccordionMentor/AccordionMentor.module.css
@@ -135,6 +135,10 @@
 		padding: 10px;
 	}
 
+	.move-title.accordion[open] .title {
+		display: none;
+	}
+
 	.media {
 		display: none;
 	}
@@ -149,11 +153,11 @@
 	.with-media .content p:last-child {
 		max-width: 100%;
 	}
-	
+
 	.heading {
 		flex-wrap: wrap;
 	}
-	
+
 	h3.title {
 		order: 3;
 		margin-top: 10px;


### PR DESCRIPTION
YH-2294
Updated the YH-1904 changes for the current develop branch 
(https://tracker.yandex.ru/YH-1904)

## Changes
- Verified that the numbered block title font size matches the design — 20px.
- Reduced the gap between numbered blocks from 20px to 10px.
- Replaced opacity: 0 with display: none for the hidden accordion title on mobile, removing it from the document flow and reducing the excessive spacing between the number and the visible subtitle.